### PR TITLE
[WIP] Updates to data_generator

### DIFF
--- a/hippyflow/modeling/dataGenerator.py
+++ b/hippyflow/modeling/dataGenerator.py
@@ -119,6 +119,7 @@ class DataGenerator:
 
 		# Begin iteration index
 		i = 0
+		exceptions_count = 0
 		while i < n_samples:
 			try:
 				t0_samplei = time.time()
@@ -129,10 +130,13 @@ class DataGenerator:
 				self.m.zero()
 				if self.settings['reset_initial_guess']:
 					self.u.zero()
+					print('reset init guess')
 				self.prior.sample(self.noise,self.m)
+				print('sampled m', self.m.get_local())
 
 				if self.control_distribution is not None:
 					self.control_distribution.sample(self.z)
+					print('sampled z', self.z.get_local())
 					x = [self.u,self.m,None,self.z]
 				else:
 					x = [self.u,self.m,None]
@@ -226,7 +230,13 @@ class DataGenerator:
 						print(messageJz.center(80))
 				i += 1
 			except:
+				exceptions_count += 1
+				os.makedirs(data_dir+'/skipped/',exist_ok=True)
+				np.save(data_dir+'skipped/z_sample_'+str(exceptions_count)+'.npy',self.z.get_local())
+				np.save(data_dir+'skipped/m_sample_'+str(exceptions_count)+'.npy',self.m.get_local())
 				print('Issue perhaps with the forward solve, moving on.')
+		
+		print(f"Total exceptions: {exceptions_count}")
 
 		################################################################################
 		if compress:
@@ -264,7 +274,7 @@ class DataGenerator:
 			all_data = np.load(data_dir+'mq_data.npz')
 		u_data = all_data['q_data'][:n_samples_pod]
 		POD = hf.PODProjectorFromData(self.observable.problem.Vh)
-		d_POD, phi, Mphi, u_shift = POD.construct_subspace(u_data,pod_rank,method = pod_method,verify = True)
+		d_POD, phi, Mphi, u_shift = POD.construct_subspace(u_data,pod_rank,shifted = pod_shifted, method = pod_method,verify = True)
 		if True:
 			u_rank_verify = pod_rank
 			if pod_shifted:

--- a/hippyflow/modeling/dataGenerator.py
+++ b/hippyflow/modeling/dataGenerator.py
@@ -276,6 +276,7 @@ class DataGenerator:
 		np.save(data_dir+f'/POD/POD_decoder.npy',phi)
 		np.save(data_dir+f'/POD/POD_encoder.npy',Mphi)
 		np.save(data_dir+f'/POD/d_POD.npy',d_POD)
+		np.save(data_dir+f'/POD/POD_shift.npy', u_shift)
 
 		# Step 2.
 		self.compute_jacobians_in_subspace(derivatives = derivatives, output_decoder = phi, output_encoder = Mphi,\

--- a/hippyflow/modeling/dataGenerator.py
+++ b/hippyflow/modeling/dataGenerator.py
@@ -28,7 +28,7 @@ def data_generator_settings(settings = {}):
 	settings['rM'] = None
 	settings['rZ'] = None
 	settings['oversample'] = 10
-
+	settings['reset_initial_guess'] = False
 	settings['verbose'] = True
 
 	return settings
@@ -127,6 +127,8 @@ class DataGenerator:
 				self.parRandom.normal(1,self.noise)
 
 				self.m.zero()
+				if self.settings['reset_initial_guess']:
+					self.u.zero()
 				self.prior.sample(self.noise,self.m)
 
 				if self.control_distribution is not None:

--- a/hippyflow/modeling/dataGenerator.py
+++ b/hippyflow/modeling/dataGenerator.py
@@ -29,6 +29,7 @@ def data_generator_settings(settings = {}):
 	settings['rZ'] = None
 	settings['oversample'] = 10
 	settings['reset_initial_guess'] = False
+	settings['save_failed_solves'] = True 
 	settings['verbose'] = True
 
 	return settings
@@ -231,9 +232,11 @@ class DataGenerator:
 				i += 1
 			except:
 				exceptions_count += 1
-				os.makedirs(data_dir+'/skipped/',exist_ok=True)
-				np.save(data_dir+'skipped/z_sample_'+str(exceptions_count)+'.npy',self.z.get_local())
-				np.save(data_dir+'skipped/m_sample_'+str(exceptions_count)+'.npy',self.m.get_local())
+				if self.settings['save_failed_solves']:
+					os.makedirs(data_dir+'/skipped/',exist_ok=True)
+					np.save(data_dir+'skipped/m_sample_'+str(exceptions_count)+'.npy',self.m.get_local())
+					if self.z is not None:
+						np.save(data_dir+'skipped/z_sample_'+str(exceptions_count)+'.npy',self.z.get_local())
 				print('Issue perhaps with the forward solve, moving on.')
 		
 		print(f"Total exceptions: {exceptions_count}")


### PR DESCRIPTION
Fix: 
- The mean shift computed by the POD for the state data was not being saved.

New:
- Added an option to reset the initial guess going into the PDE solve, i.e. `self.u` is zeroed between solves. This is sometimes useful for problems where the initial guess from the previous solve (corresponding to a different input) is actually a bad initial guess. e.g. when using hyperelasticity problems with load increments, it's better to start on a zero initial guess. 
- Added an option to save the input parameters of the forward solve if it fails 